### PR TITLE
Fix event listener cleanup

### DIFF
--- a/src/frontend/templates/vue/src/composables/useTTS.js
+++ b/src/frontend/templates/vue/src/composables/useTTS.js
@@ -349,18 +349,18 @@ export function useTTS() {
     await downloadAudioHelper(unifiedBuffer, isDownloadComplete, progressMessage)
   }
 
+  const handleChunkProgress = (event) => {
+    progressMessage.value = event.detail.message
+  }
+
   onMounted(() => {
-    window.addEventListener('chunk-progress', (event) => {
-      progressMessage.value = event.detail.message
-    })
+    window.addEventListener('chunk-progress', handleChunkProgress)
   })
 
   onUnmounted(() => {
     stopProgressUpdates()
     reset()
-    window.removeEventListener('chunk-progress', (event) => {
-      progressMessage.value = event.detail.message
-    })
+    window.removeEventListener('chunk-progress', handleChunkProgress)
   })
 
   return {


### PR DESCRIPTION
## Summary
- ensure chunk-progress handler is removed properly in `useTTS`

## Testing
- `npm test` *(fails: Missing script)*