### PR TITLE
Fix closing tag in ModeSwitchTabs

### DIFF
--- a/src/frontend/templates/vue/src/components/ModeSwitchTabs.vue
+++ b/src/frontend/templates/vue/src/components/ModeSwitchTabs.vue
@@ -34,4 +34,4 @@
   function switchMode(mode) {
     emit('tabSwitch', mode)
   }
-  </script>s
+  </script>


### PR DESCRIPTION
## Summary
- remove stray character from ModeSwitchTabs.vue closing script tag

## Testing
- `npm run test` *(fails: Missing script)*
- `pytest -q`