### PR TITLE
Use ref for volume slider

### DIFF
--- a/src/frontend/templates/vue/src/App.vue
+++ b/src/frontend/templates/vue/src/App.vue
@@ -18,6 +18,7 @@
       @deleteAllFiles="handleDeleteAllFiles"
     />
     <MainContent
+      ref="mainContent"
       v-model:text="text"
       v-model:voice="voice"
       v-model:volume="volume"
@@ -88,6 +89,7 @@ const currentFileId = ref(null)
 const voice = ref(DEFAULT_VOICE)
 const focusedElement = ref(null)
 const fileInput = ref(null)
+const mainContent = ref(null)
 
 // Composables
 const { audioContext, gainNode } = useAudioContext()
@@ -256,9 +258,9 @@ watch(unifiedBuffer, (newBuffer) => {
 })
 
 onMounted(() => {
-  const volumeSlider = document.querySelector('.macos-slider')
-  if (volumeSlider) {
-    volumeSlider.style.setProperty('--volume-percentage', `${volume.value}%`)
+  const slider = mainContent.value?.audioControls?.volumeSlider
+  if (slider) {
+    slider.style.setProperty('--volume-percentage', `${volume.value}%`)
   }
 })
 onMounted(async () => {

--- a/src/frontend/templates/vue/src/components/AudioControls.vue
+++ b/src/frontend/templates/vue/src/components/AudioControls.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="volume-control">
     <div class="volume-slider">
-      <input 
-        type="range" 
+      <input
+        ref="volumeSlider"
+        type="range"
         class="macos-slider"
         :value="volume"
         min="0"
@@ -15,6 +16,9 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
+
+const volumeSlider = ref(null)
 const props = defineProps({
   volume: {
     type: Number,
@@ -26,4 +30,6 @@ function onVolumeInput(event) {
   const newValue = Number(event.target.value)
   emit('update:volume', newValue)
 }
+
+defineExpose({ volumeSlider })
 </script>

--- a/src/frontend/templates/vue/src/components/MainContent.vue
+++ b/src/frontend/templates/vue/src/components/MainContent.vue
@@ -28,7 +28,11 @@
           />
   
           <div class="controls-row">
-            <AudioControls :volume="localVolume" @update:volume="val => localVolume = val" />
+            <AudioControls
+              ref="audioControls"
+              :volume="localVolume"
+              @update:volume="val => localVolume = val"
+            />
   
             <PlaybackControls
               :currentMode="currentMode"
@@ -161,8 +165,9 @@ const localMultiSpeakerVoices = computed({
   get: () => props.multiSpeakerVoices,
   set: newValue => emits('update:multiSpeakerVoices', newValue)
 })
-  
+
 const focusedElement = ref(null)
+const audioControls = ref(null)
   
 function handleVolumeChange(event) {
   emits('handleVolumeChange', event)
@@ -188,5 +193,6 @@ function updateMultiSpeakerVoice({ speaker, value }) {
 function onHandleTabSwitch(newMode) {
   emits('tabSwitch', newMode)
 }
-  
+
+defineExpose({ audioControls })
 </script>


### PR DESCRIPTION
## Summary
- expose slider ref from `AudioControls.vue`
- forward the ref through `MainContent.vue`
- initialize slider style in `App.vue` using the ref

## Testing
- `pytest`