### PR TITLE
Add Vue test setup and component specs

### DIFF
--- a/src/frontend/templates/vue/package.json
+++ b/src/frontend/templates/vue/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "pinia": "^2.1.7",
@@ -17,6 +18,9 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.6.2",
     "sass": "^1.83.4",
-    "vite": "^4.4.11"
+    "vite": "^4.4.11",
+    "vitest": "^1.0.0",
+    "@vue/test-utils": "^2.4.6",
+    "jsdom": "^22.1.0"
   }
 }

--- a/src/frontend/templates/vue/src/components/__tests__/MainContent.spec.js
+++ b/src/frontend/templates/vue/src/components/__tests__/MainContent.spec.js
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import MainContent from '../MainContent.vue'
+
+const defaultProps = {
+  currentMode: 'single',
+  text: '',
+  voice: 'am_michael',
+  volume: 50,
+  multiSpeakerVoices: {},
+  isPlaying: false,
+  isGenerating: false,
+  currentSource: null,
+  playbackProgress: 0,
+  isDownloadComplete: false,
+  currentTime: 0,
+  audioDuration: 0,
+  progressMessage: '',
+  isDark: false
+}
+
+function mountComponent() {
+  return mount(MainContent, {
+    props: { ...defaultProps },
+    global: {
+      stubs: {
+        ModeSwitchTabs: { template: '<div />', emits: ['tabSwitch'] },
+        TextEntryField: true,
+        SpeakerSelection: true,
+        AudioControls: true,
+        PlaybackControls: true,
+        ProgressBar: true,
+        'v-main': true,
+        'v-container': true,
+        'v-card': true,
+        'v-card-title': true,
+        'v-card-text': true,
+        'v-btn': true,
+        'v-icon': true
+      }
+    }
+  })
+}
+
+test('emits toggleTheme when theme button clicked', async () => {
+  const wrapper = mountComponent()
+  await wrapper.find('.theme-toggle').trigger('click')
+  expect(wrapper.emitted().toggleTheme).toBeTruthy()
+})
+
+test('emits tabSwitch when ModeSwitchTabs emits tabSwitch', async () => {
+  const wrapper = mountComponent()
+  await wrapper.findComponent({ name: 'ModeSwitchTabs' }).vm.$emit('tabSwitch', 'multi')
+  expect(wrapper.emitted().tabSwitch[0]).toEqual(['multi'])
+})

--- a/src/frontend/templates/vue/src/components/__tests__/SpeakerSelection.spec.js
+++ b/src/frontend/templates/vue/src/components/__tests__/SpeakerSelection.spec.js
@@ -1,0 +1,49 @@
+import { mount } from '@vue/test-utils'
+import SpeakerSelection from '../SpeakerSelection.vue'
+import { VOICE_OPTIONS, VOICES_BY_PIPELINE } from '../../constants/voices'
+
+test('emits update:voice when voice changed in single mode', async () => {
+  const wrapper = mount(SpeakerSelection, {
+    props: {
+      currentMode: 'single',
+      voice: 'am_michael',
+      multiSpeakerVoices: {},
+      voiceOptions: VOICE_OPTIONS
+    }
+  })
+
+  const selects = wrapper.findAll('select')
+  await selects[1].setValue('af_alloy')
+  expect(wrapper.emitted()['update:voice'][0]).toEqual(['af_alloy'])
+})
+
+test('changing pipeline emits first voice of new pipeline', async () => {
+  const wrapper = mount(SpeakerSelection, {
+    props: {
+      currentMode: 'single',
+      voice: 'am_michael',
+      multiSpeakerVoices: {},
+      voiceOptions: VOICE_OPTIONS
+    }
+  })
+
+  const pipelineSelect = wrapper.findAll('select')[0]
+  await pipelineSelect.setValue('british')
+  const expected = VOICES_BY_PIPELINE['british'][0].value
+  expect(wrapper.emitted()['update:voice'][0]).toEqual([expected])
+})
+
+test('emits update-multi-speaker-voice when multi voice changed', async () => {
+  const wrapper = mount(SpeakerSelection, {
+    props: {
+      currentMode: 'multi',
+      multiSpeakerVoices: { 1: 'am_michael' },
+      voiceOptions: VOICE_OPTIONS,
+      speakerCount: 2
+    }
+  })
+
+  const select = wrapper.findAll('select')[0]
+  await select.setValue('af_alloy')
+  expect(wrapper.emitted()['update-multi-speaker-voice'][0]).toEqual([{ speaker: 1, value: 'af_alloy' }])
+})

--- a/src/frontend/templates/vue/vite.config.js
+++ b/src/frontend/templates/vue/vite.config.js
@@ -7,6 +7,10 @@ const backendUrl = process.env.DOCKER_ENV
 
 export default defineConfig({
   plugins: [vue()],
+  test: {
+    globals: true,
+    environment: 'jsdom'
+  },
   server: {
     proxy: {
       '/generate': backendUrl,


### PR DESCRIPTION
## Summary
- configure vitest in template `vite.config.js`
- add test command and dev dependencies
- add basic tests for `MainContent.vue`
- add basic tests for `SpeakerSelection.vue`

## Testing
- `npm test` *(fails: vitest not found)*