### PR TITLE
Allow DB path override via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ brew install espeak-ng
    ```bash
    python src/backend/main.py
    ```
+4. (Optional) Override the default SQLite path by setting `TORCHTS_DB_URL`:
+   ```bash
+   export TORCHTS_DB_URL=sqlite:////absolute/path/to/torchts.db
+   ```
 
 #### Frontend Setup (Vue.js)
 

--- a/src/backend/storage/models.py
+++ b/src/backend/storage/models.py
@@ -2,9 +2,18 @@ from sqlalchemy import create_engine, Column, Integer, String, ForeignKey, DateT
 from sqlalchemy.orm import declarative_base, relationship, Session
 from datetime import datetime, timezone
 import os
+from pathlib import Path
 
-# Create the database directory if it doesn't exist
-os.makedirs('data', exist_ok=True)
+# Determine database location
+db_url = os.getenv("TORCHTS_DB_URL")
+if db_url is None:
+    db_path = Path.cwd() / "data" / "torchts.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_url = f"sqlite:///{db_path}"
+else:
+    if db_url.startswith("sqlite:///"):
+        db_file = db_url[len("sqlite:///") :]
+        Path(db_file).parent.mkdir(parents=True, exist_ok=True)
 
 # Define a naming convention for indexes and constraints
 metadata = MetaData(naming_convention={
@@ -68,7 +77,7 @@ class AudioOutput(Base):
         return f"<AudioOutput(id={self.id}, file_path={self.file_path})>"
 
 # Create engine
-engine = create_engine('sqlite:///data/torchts.db')
+engine = create_engine(db_url)
 
 # Create all tables
 Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- allow overriding SQLite database location via `TORCHTS_DB_URL`
- document new environment variable in README

## Testing
- `python -m py_compile src/backend/storage/models.py`