### PR TITLE
Refactor playback state into Pinia store

### DIFF
--- a/frontend/src/composables/useAudioChunks.js
+++ b/frontend/src/composables/useAudioChunks.js
@@ -1,10 +1,12 @@
 import { ref } from 'vue'
 import { useAPI } from './useAPI'
 import { concatenateAudioBuffers } from '../utils/audioHelpers'
+import { useTTSStore } from '../stores/ttsStore'
 
 export function useAudioChunks(audioContext) {
+  const ttsStore = useTTSStore()
+  const { downloadProgress, setDownloadProgress } = ttsStore
   const chunkCache = new Map()
-  const downloadProgress = ref(0)
   const currentChunkIndex = ref(0)
   let totalChunks = 0
   let validatedTotalChunks = null
@@ -45,7 +47,7 @@ export function useAudioChunks(audioContext) {
 
       if (!chunkCache.has(currentChunk)) {
         chunkCache.set(currentChunk, audioBuffer)
-        downloadProgress.value = Math.round((chunkCache.size / totalChunks) * 100)
+        setDownloadProgress(Math.round((chunkCache.size / totalChunks) * 100))
       }
 
       return {
@@ -135,7 +137,6 @@ export function useAudioChunks(audioContext) {
 
   return {
     chunkCache,
-    downloadProgress,
     currentChunkIndex,
     fetchAudioChunk,
     fetchNextChunks,

--- a/frontend/src/stores/ttsStore.js
+++ b/frontend/src/stores/ttsStore.js
@@ -8,6 +8,16 @@ export const useTTSStore = defineStore('tts', () => {
   const unifiedBuffer = ref(null)
   const audioDuration = ref(0)
 
+  // Playback state
+  const isPlaying = ref(false)
+  const currentSource = ref(null)
+  const playbackProgress = ref(0)
+  const currentTime = ref(0)
+
+  // Download state
+  const isDownloadComplete = ref(false)
+  const downloadProgress = ref(0)
+
   function setVolume(val) {
     volume.value = val
   }
@@ -21,13 +31,51 @@ export const useTTSStore = defineStore('tts', () => {
     }
   }
 
+  // Playback actions
+  function setIsPlaying(val) {
+    isPlaying.value = val
+  }
+
+  function setCurrentSource(source) {
+    currentSource.value = source
+  }
+
+  function setPlaybackProgress(progress) {
+    playbackProgress.value = progress
+  }
+
+  function setCurrentTime(time) {
+    currentTime.value = time
+  }
+
+  // Download actions
+  function setIsDownloadComplete(val) {
+    isDownloadComplete.value = val
+  }
+
+  function setDownloadProgress(val) {
+    downloadProgress.value = val
+  }
+
   return {
     volume,
     isGenerating,
     progressMessage,
     unifiedBuffer,
     audioDuration,
+    isPlaying,
+    currentSource,
+    playbackProgress,
+    currentTime,
+    isDownloadComplete,
+    downloadProgress,
     setVolume,
-    setUnifiedBuffer
+    setUnifiedBuffer,
+    setIsPlaying,
+    setCurrentSource,
+    setPlaybackProgress,
+    setCurrentTime,
+    setIsDownloadComplete,
+    setDownloadProgress
   }
 })


### PR DESCRIPTION
## Summary
- extend ttsStore with playback and download refs plus setter actions
- have audio chunk helpers update progress via the store
- rewrite playback composable to read/write state from ttsStore
- refactor useTTS composable to use new store actions and refs

## Testing
- `npm test` *(fails: vitest not found)*
- `pytest -q`