### PR TITLE
Move watchers into Pinia stores

### DIFF
--- a/frontend/src/composables/usePlayback.js
+++ b/frontend/src/composables/usePlayback.js
@@ -5,7 +5,7 @@ export function usePlayback(audioContext, gainNode) {
   const ttsStore = useTTSStore()
   const {
     volume,
-    setVolume: updateVolume,
+    setVolumeAndApply,
     isPlaying,
     currentSource,
     playbackProgress,
@@ -115,9 +115,8 @@ export function usePlayback(audioContext, gainNode) {
   }
 
   function handleVolumeChange(event, setVolume) {
-    const newVol = parseFloat(event.target.value) / 100
-    updateVolume(parseInt(event.target.value))
-    setVolume(newVol)
+    const newVol = parseInt(event.target.value)
+    setVolumeAndApply(newVol, setVolume)
     event.target.style.setProperty('--volume-percentage', `${volume.value}%`)
   }
 

--- a/frontend/src/composables/useTTS.js
+++ b/frontend/src/composables/useTTS.js
@@ -21,7 +21,7 @@ export function useTTS() {
     currentTime,
     isDownloadComplete,
     downloadProgress,
-    setUnifiedBuffer,
+    updateUnifiedBuffer,
     setIsPlaying,
     setCurrentSource,
     setPlaybackProgress,
@@ -84,7 +84,7 @@ export function useTTS() {
       setIsDownloadComplete(false)
       setDownloadProgress(0)
       audioQueue.length = 0
-      setUnifiedBuffer(null)
+      updateUnifiedBuffer(null, setTotalDuration)
       // make sure we start in streaming mode for new generations:
       streamingMode = true
 
@@ -114,8 +114,7 @@ export function useTTS() {
       }
 
       if (totalChunks === 1) {
-        setUnifiedBuffer(firstChunk.buffer)
-        setTotalDuration(unifiedBuffer.value.duration)
+        updateUnifiedBuffer(firstChunk.buffer, setTotalDuration)
         setIsDownloadComplete(true)
       } else {
         fetchNextChunks(text, voice, isGenerating, unifiedBuffer, audioQueue, isDownloadComplete)
@@ -240,7 +239,7 @@ export function useTTS() {
       setDownloadProgress(0)
       audioQueue.length = 0
       chunkCache.clear()
-      setUnifiedBuffer(null)
+      updateUnifiedBuffer(null, setTotalDuration)
       // For multi-speaker we immediately get a full WAV; so switch to unifiedBuffer mode:
       streamingMode = false
 
@@ -265,9 +264,10 @@ export function useTTS() {
 
       const sessionId = multiResponse.sessionId
       const arrayBuffer = multiResponse.arrayBuffer
-      setUnifiedBuffer(await audioContext.value.decodeAudioData(arrayBuffer))
-
-      setTotalDuration(unifiedBuffer.value.duration)
+      updateUnifiedBuffer(
+        await audioContext.value.decodeAudioData(arrayBuffer),
+        setTotalDuration
+      )
       setIsDownloadComplete(true)
 
       currentSource.value = audioContext.value.createBufferSource()
@@ -347,7 +347,7 @@ export function useTTS() {
     resetChunks()
     audioQueue.length = 0
     currentChunkIndex.value = 0
-    setUnifiedBuffer(null)
+    updateUnifiedBuffer(null, setTotalDuration)
     setDownloadProgress(0)
     setPlaybackProgress(0)
     setIsDownloadComplete(false)

--- a/frontend/src/stores/fileUploadStore.js
+++ b/frontend/src/stores/fileUploadStore.js
@@ -184,6 +184,12 @@ export const useFileUploadStore = defineStore('fileUpload', () => {
     }
   }
 
+  function clearCurrentFileIfTextEdited(newText) {
+    if (currentFileId.value && newText !== originalFileContent.value) {
+      currentFileId.value = null
+    }
+  }
+
   return {
     uploadedFiles,
     progressMessage,
@@ -204,6 +210,7 @@ export const useFileUploadStore = defineStore('fileUpload', () => {
     processFile,
     handleFileSelect,
     handleFileDrop,
-    handleFileClick
+    handleFileClick,
+    clearCurrentFileIfTextEdited
   }
 })

--- a/frontend/src/stores/ttsStore.js
+++ b/frontend/src/stores/ttsStore.js
@@ -57,6 +57,21 @@ export const useTTSStore = defineStore('tts', () => {
     downloadProgress.value = val
   }
 
+  function setVolumeAndApply(val, applyFn) {
+    volume.value = val
+    if (typeof applyFn === 'function') {
+      applyFn(val / 100)
+    }
+  }
+
+  function updateUnifiedBuffer(buffer, setDuration) {
+    setUnifiedBuffer(buffer)
+    if (typeof setDuration === 'function') {
+      const duration = buffer ? buffer.duration : 0
+      setDuration(duration)
+    }
+  }
+
   return {
     volume,
     isGenerating,
@@ -76,6 +91,8 @@ export const useTTSStore = defineStore('tts', () => {
     setPlaybackProgress,
     setCurrentTime,
     setIsDownloadComplete,
-    setDownloadProgress
+    setDownloadProgress,
+    setVolumeAndApply,
+    updateUnifiedBuffer
   }
 })

--- a/frontend/src/utils/generalHelpers.js
+++ b/frontend/src/utils/generalHelpers.js
@@ -52,7 +52,7 @@ export function cancelTabSwitch({ pendingTabSwitch, showTabSwitchDialog }) {
 
 // --- New keydown handler helper function ---
 
-export function handleKeydown(event, { currentSource, togglePlayback, volume, setVolume, seekRelative }) {
+export function handleKeydown(event, { currentSource, togglePlayback, volume, applyVolume, seekRelative }) {
   if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA') return;
 
   switch (event.code) {
@@ -65,14 +65,20 @@ export function handleKeydown(event, { currentSource, togglePlayback, volume, se
     case 'ArrowUp':
       event.preventDefault();
       const newVolUp = Math.min(100, volume.value + 5);
-      volume.value = newVolUp;
-      setVolume(newVolUp / 100);
+      if (applyVolume) {
+        applyVolume(newVolUp);
+      } else {
+        volume.value = newVolUp;
+      }
       break;
     case 'ArrowDown':
       event.preventDefault();
       const newVolDown = Math.max(0, volume.value - 5);
-      volume.value = newVolDown;
-      setVolume(newVolDown / 100);
+      if (applyVolume) {
+        applyVolume(newVolDown);
+      } else {
+        volume.value = newVolDown;
+      }
       break;
     case 'ArrowLeft':
       event.preventDefault();


### PR DESCRIPTION
## Summary
- add `clearCurrentFileIfTextEdited` to `fileUploadStore`
- handle volume and buffer updates with new actions in `ttsStore`
- use the new store actions from composables and `App.vue`
- update keydown helper to use new volume action

## Testing
- `npm test` *(fails: vitest not installed)*
- `pytest -q`