### PR TITLE
Fix duplicate variable in App.vue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -65,7 +65,6 @@ import {
 
 // State
 const ttsStore = useTTSStore()
-const { unifiedBuffer, audioDuration } = storeToRefs(ttsStore)
 
 const text = ref('')
 const voice = ref(DEFAULT_VOICE)


### PR DESCRIPTION
## Summary
- remove duplicate `audioDuration` declaration in App.vue
- ensure file ends with a newline

## Testing
- `pytest -q`