### PR TITLE
Fix convert to speech null audio context

### DIFF
--- a/frontend/src/composables/useTTS.js
+++ b/frontend/src/composables/useTTS.js
@@ -71,7 +71,7 @@ export function useTTS() {
       currentAbortController = new AbortController()
       
       initAudio()
-      if (audioContext.value.state === 'suspended') {
+      if (audioContext.value && audioContext.value.state === 'suspended') {
         await audioContext.value.resume()
       }
 
@@ -226,7 +226,7 @@ export function useTTS() {
 
     try {
       initAudio()
-      if (audioContext.value.state === 'suspended') {
+      if (audioContext.value && audioContext.value.state === 'suspended') {
         await audioContext.value.resume()
       }
 


### PR DESCRIPTION
## Summary
- guard against `audioContext` being null when attempting to resume playback

## Testing
- `pytest -q`
